### PR TITLE
Crash all (host)

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -1,5 +1,6 @@
 using Sentry.Internal.Extensions;
 using UnityEngine;
+using Hazel;
 
 namespace MalumMenu;
 public static class MalumCheats
@@ -314,4 +315,16 @@ public static class MalumCheats
         catch{}
     }
 
+	public static void crashEveryoneOHMYPC()
+	{
+		// (Host) Send custom RPC to ALL clients to something that the server doesn't respond to
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(
+            target.NetId,
+            250,  // 250
+            SendOption.Reliable,
+            -1 // Broadcast to everyone
+        );
+        writer.Write(target.PlayerId);
+        AmongUsClient.Instance.FinishRpcImmediately(writer);
+	}
 }

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -48,3 +48,15 @@ public static class PlayerPhysics_LateUpdate
         }
     }
 }
+
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.HandleRpc))]
+class CrashEveryoneOHMYPC_HandleRpc
+{
+    static void Postfix(PlayerControl __instance, byte callId, MessageReader reader)
+    {
+        if (callId == 250) // custom
+        {
+            //dont respond at all
+        }
+    }
+}

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -19,6 +19,7 @@ public static class PlayerPhysics_LateUpdate
         MalumCheats.killAllImpsCheat();
         MalumCheats.teleportCursorCheat();
         MalumCheats.completeMyTasksCheat();
+        MalumCheats.crashEveryoneOHMYPC
 
         MalumPPMCheats.spectatePPM();
         MalumPPMCheats.killPlayerPPM();

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -19,7 +19,7 @@ public static class PlayerPhysics_LateUpdate
         MalumCheats.killAllImpsCheat();
         MalumCheats.teleportCursorCheat();
         MalumCheats.completeMyTasksCheat();
-        MalumCheats.crashEveryoneOHMYPC
+        MalumCheats.crashEveryoneOHMYPC();
 
         MalumPPMCheats.spectatePPM();
         MalumPPMCheats.killPlayerPPM();

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -49,15 +49,3 @@ public static class PlayerPhysics_LateUpdate
         }
     }
 }
-
-[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.HandleRpc))]
-class CrashEveryoneOHMYPC_HandleRpc
-{
-    static void Postfix(PlayerControl __instance, byte callId, MessageReader reader)
-    {
-        if (callId == 250) // custom
-        {
-            //dont respond at all
-        }
-    }
-}

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -83,6 +83,7 @@ namespace MalumMenu
         //public static bool godMode;
         //public static bool evilVote;
         //public static bool voteImmune;
+        public static bool crashEveryoneOHMYPC;
 
         //Passive
         public static bool unlockFeatures = true;

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -124,6 +124,7 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" Kill While Vanished", () => CheatToggles.killVanished, x => CheatToggles.killVanished = x),
             new ToggleInfo(" Kill Anyone", () => CheatToggles.killAnyone, x => CheatToggles.killAnyone = x),
             new ToggleInfo(" No Kill Cooldown", () => CheatToggles.zeroKillCd, x => CheatToggles.zeroKillCd = x),
+            new ToggleInfo(" Crash everyone", () => CheatToggles.crashEveryoneOHMYPC, x => CheatToggles.crashEveryoneOHMYPC = x),
         },
         new List<SubmenuInfo>{
             new SubmenuInfo("Murder", false, new List<ToggleInfo>() {

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -104,7 +104,7 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" Unlock Textbox", () => CheatToggles.chatJailbreak, x => CheatToggles.chatJailbreak = x)
         }, new List<SubmenuInfo>()));
 
-        // Host-Only cheats are temporarly disabled because of some bugs
+        // Host-Only cheats are temporarily disabled because of some bugs
 
         //groups.Add(new GroupInfo("Host-Only", false, new List<ToggleInfo>() {
         //    new ToggleInfo(" ImpostorHack", () => CheatSettings.impostorHack, x => CheatSettings.impostorHack = x),
@@ -113,7 +113,7 @@ public class MenuUI : MonoBehaviour
         //    new ToggleInfo(" VoteImmune", () => CheatSettings.voteImmune, x => CheatSettings.voteImmune = x)
         //}, new List<SubmenuInfo>()));
 
-        // Console is temporarly disabled until we implement some features for it
+        // Console is temporarily disabled until we implement some features for it
 
         //groups.Add(new GroupInfo("Console", false, new List<ToggleInfo>() {
         //    new ToggleInfo(" ConsoleUI", () => MalumMenu.consoleUI.isVisible, x => MalumMenu.consoleUI.isVisible = x),


### PR DESCRIPTION
Sends an RPC with the code "250" to all clients, which causes all clients to be kicked due to a "server not responded" error, since this is not a valid or recognized RPC.
(Ignore the comments I changed, I was testing)