### PR TITLE
Close game cheat

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -469,4 +469,15 @@ public static class MalumCheats
             AmongUsClient.Instance.LateBroadcastReliableMessage(Unsafe.As<IGameDataMessage>(rpcMessage));
         }
     }
+
+	//Heres how it works. When the loading bar appears, when you activate this cheat it will call a meeting.
+	//The game closes as "crewmates dead" because the players aren't loaded in yet.
+	//Will cause the lobby to close, (Sometimes the host can play again to restore the lobby)
+	public static void CloseGameCheat()
+    {
+        if (CheatToggles.closeGame && !Utils.isLobby) // Can be known as crash game, but close game is the closest answer if this doesn't work remove the isLobby check.
+        {
+			PlayerControl.LocalPlayer.CmdReportDeadBody(null);
+        }
+    }
 }

--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -479,5 +479,6 @@ public static class MalumCheats
         {
 			PlayerControl.LocalPlayer.CmdReportDeadBody(null);
         }
+		CheatToggles.closeGame = false;
     }
 }

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -23,6 +23,7 @@ public static class PlayerPhysics_LateUpdate
         MalumCheats.completeMyTasksCheat();
         MalumCheats.AnimationCheat();
         MalumCheats.ScanCheat();
+        MalumCheats.CloseGameCheat();
 
         MalumPPMCheats.ejectPlayerPPM();
         MalumPPMCheats.spectatePPM();

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -87,6 +87,7 @@ public struct CheatToggles
     public static bool logVents;
 
     //Ship
+    public static bool closeGame;
     public static bool closeMeeting;
     public static bool sabotageMap;
     public static bool openAllDoors;

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -312,7 +312,7 @@ public class MenuUI : MonoBehaviour
 
         //Some cheats only work if the ship is present, so they are turned off if it is not
         if(!Utils.isShip){
-            CheatToggles.revive = CheatToggles.sabotageMap = CheatToggles.unfixableLights = CheatToggles.completeMyTasks = CheatToggles.kickVents = CheatToggles.reportBody = CheatToggles.ejectPlayer = CheatToggles.closeMeeting = CheatToggles.skipMeeting = CheatToggles.reactorSab = CheatToggles.oxygenSab = CheatToggles.commsSab = CheatToggles.elecSab = CheatToggles.mushSab = CheatToggles.closeAllDoors = CheatToggles.openAllDoors = CheatToggles.spamCloseAllDoors = CheatToggles.spamOpenAllDoors = CheatToggles.autoOpenDoorsOnUse = CheatToggles.mushSpore = CheatToggles.animShields = CheatToggles.animAsteroids = CheatToggles.animEmptyGarbage = CheatToggles.animScan = CheatToggles.animCamsInUse = CheatToggles.closeGame = false;
+            CheatToggles.revive = CheatToggles.sabotageMap = CheatToggles.unfixableLights = CheatToggles.completeMyTasks = CheatToggles.kickVents = CheatToggles.reportBody = CheatToggles.ejectPlayer = CheatToggles.closeMeeting = CheatToggles.skipMeeting = CheatToggles.reactorSab = CheatToggles.oxygenSab = CheatToggles.commsSab = CheatToggles.elecSab = CheatToggles.mushSab = CheatToggles.closeAllDoors = CheatToggles.openAllDoors = CheatToggles.spamCloseAllDoors = CheatToggles.spamOpenAllDoors = CheatToggles.autoOpenDoorsOnUse = CheatToggles.mushSpore = CheatToggles.animShields = CheatToggles.animAsteroids = CheatToggles.animEmptyGarbage = CheatToggles.animScan = CheatToggles.animCamsInUse = false;
         }
     }
 

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -113,6 +113,7 @@ public class MenuUI : MonoBehaviour
             ]));
 
         groups.Add(new GroupInfo("Ship", false, [
+            new ToggleInfo(" Close Game", () => CheatToggles.closeGame, x => CheatToggles.closeGame = x),
             new ToggleInfo(" Unfixable Lights", () => CheatToggles.unfixableLights, x => CheatToggles.unfixableLights = x),
             new ToggleInfo(" Report Body", () => CheatToggles.reportBody, x => CheatToggles.reportBody = x),
             new ToggleInfo(" Call Meeting", () => CheatToggles.callMeeting, x => CheatToggles.callMeeting = x),
@@ -311,7 +312,7 @@ public class MenuUI : MonoBehaviour
 
         //Some cheats only work if the ship is present, so they are turned off if it is not
         if(!Utils.isShip){
-            CheatToggles.revive = CheatToggles.sabotageMap = CheatToggles.unfixableLights = CheatToggles.completeMyTasks = CheatToggles.kickVents = CheatToggles.reportBody = CheatToggles.ejectPlayer = CheatToggles.closeMeeting = CheatToggles.skipMeeting = CheatToggles.reactorSab = CheatToggles.oxygenSab = CheatToggles.commsSab = CheatToggles.elecSab = CheatToggles.mushSab = CheatToggles.closeAllDoors = CheatToggles.openAllDoors = CheatToggles.spamCloseAllDoors = CheatToggles.spamOpenAllDoors = CheatToggles.autoOpenDoorsOnUse = CheatToggles.mushSpore = CheatToggles.animShields = CheatToggles.animAsteroids = CheatToggles.animEmptyGarbage = CheatToggles.animScan = CheatToggles.animCamsInUse = false;
+            CheatToggles.revive = CheatToggles.sabotageMap = CheatToggles.unfixableLights = CheatToggles.completeMyTasks = CheatToggles.kickVents = CheatToggles.reportBody = CheatToggles.ejectPlayer = CheatToggles.closeMeeting = CheatToggles.skipMeeting = CheatToggles.reactorSab = CheatToggles.oxygenSab = CheatToggles.commsSab = CheatToggles.elecSab = CheatToggles.mushSab = CheatToggles.closeAllDoors = CheatToggles.openAllDoors = CheatToggles.spamCloseAllDoors = CheatToggles.spamOpenAllDoors = CheatToggles.autoOpenDoorsOnUse = CheatToggles.mushSpore = CheatToggles.animShields = CheatToggles.animAsteroids = CheatToggles.animEmptyGarbage = CheatToggles.animScan = CheatToggles.animCamsInUse = CheatToggles.closeGame = false;
         }
     }
 


### PR DESCRIPTION
Here's how it works. When the loading bar appears, when you activate this cheat it will call a meeting.

The game closes as "crewmates dead" because the players aren't loaded in yet.

Will cause the lobby to close, (Sometimes the host can play again to restore the lobby)

This cheat doesn't require host permissions, so you can technically "crash" games to be more specific close games.

You can edit any mistakes or anything else I missed.